### PR TITLE
Watched resources path for fixtures in plugins incorrect

### DIFF
--- a/FitnesseGrailsPlugin.groovy
+++ b/FitnesseGrailsPlugin.groovy
@@ -39,7 +39,7 @@ class FitnesseGrailsPlugin {
 
     def watchedResources = [
             "file:./grails-app/fitnesse/**/*.groovy",
-            "file:../../plugins/*/grails-app/fitnesse/**/*.groovy"
+            "file:./plugins/*/grails-app/fitnesse/**/*.groovy"
     ]
 
     def doWithWebDescriptor = { xml ->


### PR DESCRIPTION
Erik -
This pull updates the path for watchedResources inside the plugin descriptor to be correct for paths to fitnesse artifacts in plugins. It was trying to access a plugins directory that was 2 levels above the application root.
