### PR TITLE
Fix _Events.groovy and _Install.groovy

### DIFF
--- a/scripts/_Install.groovy
+++ b/scripts/_Install.groovy
@@ -11,6 +11,4 @@
 
 ant.mkdir(dir:"${basedir}/grails-app/fitnesse")
 //ant.mkdir(dir:"${basedir}/test/fitnesse")
-ant.touch(file:".donotdelete", mkdirs:true) {
-    ant.fileset(dir:"${basedir}/test/fitnesse")
-}
+ant.touch(file:"${basedir}/test/fitnesse/.donotdelete", mkdirs:true) 


### PR DESCRIPTION
The plugin doesn't work if you also have the Functional test plugin installed do to a conflict with the closure names in _Events.groovy. It appears they aren't namespaced. I renamed the methods so they shouldn't conflict and it runs now. I test this with a local Grails 1.3.8 project that also had the functional test plugin installed.

I also noticed that _Install.groovy was putting the .donotdelete file into the application's root and not test/fitnesse. I didn't test this, but it appears correct according to the Ant documentation.

John
