### PR TITLE
Remove println statement in result parser

### DIFF
--- a/src/groovy/nl/jworks/grails/plugin/fitnesse/testrunner/FitnesseXmlResultParser.groovy
+++ b/src/groovy/nl/jworks/grails/plugin/fitnesse/testrunner/FitnesseXmlResultParser.groovy
@@ -11,7 +11,7 @@ class FitnesseXmlResultParser {
     private final Logger log = LoggerFactory.getLogger(getClass())
 
     FitnesseTotalResult parseFitnesseXml(String xml) {
-        println "Parsing Fitnesse xml: $xml"
+        //println "Parsing Fitnesse xml: $xml"
 
         GPathResult testResults = parseXml(xml)
 


### PR DESCRIPTION
Hey Erik -
Just a quick patch. No need to release an update for it, just wanted to get it into the code base. There's a println in the FitnesseXmlResultParser that dumps the entire XML result to standard out.

I see there are a couple more, but I think those are ok:
FitNesseTestReporter -> prints out if it couldn't parse the XML
NonStaticFitnesseMain -> prints out command args/usage
GrailsFitnesseTestType -> print out Fitnesse args.
