### PR TITLE
Remove exception strack trace print when loading class

### DIFF
--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -33,7 +33,6 @@ tryToLoadFitnesseTestTypes = {
 }
 
 eventAllTestsStart = {
-    phasesToRun << "fitnesse"
     runningTests = true
     
     tryToLoadFitnesseTestTypes()

--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -11,7 +11,7 @@ softLoadFitnesseClass = { className ->
     try {
         classLoader.loadClass(className)
     } catch (ClassNotFoundException e) {
-        e.printStackTrace()
+        null
     }
 }
 


### PR DESCRIPTION
Erik -
another quick clean up to the _Events.groovy script. Just removes an exception print stack trace that is unnecessary. No need to release an update.

-John
